### PR TITLE
Fixing Stack Ordering for Menu

### DIFF
--- a/src/DropdownContainer/Components.js
+++ b/src/DropdownContainer/Components.js
@@ -67,4 +67,6 @@ export const InvertedDiv = styled.div`
   position: ${props => (props.absolute ? "absolute" : "relative")};
   top:0;
   left:0;
+  &:first-of-type{ z-index: 1; }
+  &:not(:first-of-type) { z-index: -1; }
 `


### PR DESCRIPTION
As detailed in [React Flip Toolkit # 23](https://github.com/aholachek/react-flip-toolkit/issues/23) - the InvertedDiv or children of the Flipped component are subject to "dom blocking". One div will layer on top of another, causing components below to be functionality inoperable, even if they appear and the others do not.. (aka dropdown menu links become un-clickable)

![screen recording 2018-10-02 at 10 18 am](https://user-images.githubusercontent.com/5290878/46498551-5dccb300-c7e3-11e8-8bf0-98f1fb315786.gif)

This short PR fixes the problem!